### PR TITLE
Make the PoC work

### DIFF
--- a/Receiver-NServiceBus/HelloMessageHandler.cs
+++ b/Receiver-NServiceBus/HelloMessageHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using NServiceBus;
 
 namespace Receiver_NServiceBus
@@ -8,6 +9,7 @@ namespace Receiver_NServiceBus
         public Task Handle(Incoming message, IMessageHandlerContext context)
         {
             var x = message.Message;
+            Console.WriteLine(x);
             return Task.CompletedTask;
         }
     }


### PR DESCRIPTION
Hi @dahlsailrunner,

A couple things were needed to make your POC work:

First (and easiest), in your Sender, you have the queue being created as durable, so I don't know why you were calling NServiceBus's `UseDurableExchangesAndQueues(false)` option. The endpoint was throwing an error on startup because the queue wasn't in the state it expected. So I just commented that line out.

The second one is a much bigger deal: NServiceBus has to be able to figure out what type of message you're sending it. Normally NServiceBus would add a header called `NServiceBus.EnclosedMessageTypes` which would include the full assembly-qualified type, but on the receiving end it's capable of dealing with just full type name. (No assembly.)

In your case, that was completely different on both the sender and receiver, you just had 2 completely differently named classes that happened to have the same serialized structure.

I solved this by creating a behavior on the incoming physical message stage (when the payload is just a stream and hasn't been deserialized to an object yet) that assumes ALL incoming messages will be of type `Receiver_NServiceBus.Incoming`. Then I registered that behavior into the NServiceBus pipeline.

Clearly this isn't production worthy, but should illuminate for you what NServiceBus is doing. On the sender side you could just include the header NServiceBus expects. That's probably easiest if you have control of the sender side. If you're trying to implement something where you want to consume something that an external, out-of-your-control system is doing, then the behavior route is the way to go, where you would create logic that would figure out (from whatever headers are available) what this thing is, and then fill in the type like my behavior does.